### PR TITLE
Fix menu icon functions

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -134,7 +134,10 @@ class MenuScene(SceneBase):
             for rect, label, key in self.icon_rects:
                 if rect.collidepoint(evt.pos):
                     if label == 'Cancel':
-                        self.game.change_scene(SCENE_MENU)
+                        pygame.quit()
+                        sys.exit()
+                    elif label == 'Settings':
+                        self.game.change_scene(SCENE_SETTINGS)
                     else:
                         self.game.selected_school = label
                         self.game.selected_key = key


### PR DESCRIPTION
## Summary
- fix cancel icon to close the game
- fix settings icon to open settings menu

## Testing
- `python3 -m py_compile src/main.py`
- `SDL_VIDEODRIVER=dummy python3 src/main.py` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_6840009942cc832bae005ca7f11f2ae1